### PR TITLE
added errbot commands for ECS

### DIFF
--- a/adsaws.py
+++ b/adsaws.py
@@ -21,6 +21,8 @@ class AdsAws(BotPlugin):
         help += '> *!aws ec2info*: get the status of all the ADS AWS EC2 instances\n'
         help += '> *!aws ec2get*: get the property of an ADS AWS EC2 instance\n'
         help += '> *!aws ecsclusters*: get a list of ECS clusters with their ARN\n'
+        help += '> *!aws ecsclusterinfo*: get a list of properties for a given ECS cluster\n'
+        help += '> *!aws ecsclusterinfo*: get status info for a given ECS cluster\n'
         return help
 
     @botcmd
@@ -73,7 +75,7 @@ class AdsAws(BotPlugin):
         """
         :param msg: msg sent
         :param args: arguments passed
-        Return properties for a given ECS clusters
+        Return properties for a given ECS cluster
         """
         args = args.split(' ')
         if len(args) != 1:

--- a/adsaws.py
+++ b/adsaws.py
@@ -20,6 +20,7 @@ class AdsAws(BotPlugin):
         help = '**ADS AWS Commands**\n'
         help += '> *!aws ec2info*: get the status of all the ADS AWS EC2 instances\n'
         help += '> *!aws ec2get*: get the property of an ADS AWS EC2 instance\n'
+        help += '> *!aws ecsclusters*: get a list of ECS clusters with their ARN\n'
         return help
 
     @botcmd
@@ -54,6 +55,62 @@ class AdsAws(BotPlugin):
         for value in values:
             return_msg += '> {}: {}\n'.format(list(value.keys())[0], list(value.values())[0])
 
+        return return_msg
+
+    @botcmd
+    def aws_ecsclusters(self):
+        """
+        Return the ARNs for the ECS clusters
+        """
+        cluster_info = get_ecs_info()
+        return_msg = '**ADS AWS ECS Clusters**\n'
+        for entry in cluster_info.get('clusterArns'):
+            return_msg += '> {}: {}\n'.format(entry.split('/')[1], entry)
+        return return_msg
+
+    @botcmd
+    def aws_ecsclusterinfo(self, msg, args):
+        """
+        :param msg: msg sent
+        :param args: arguments passed
+        Return properties for a given ECS clusters
+        """
+        args = args.split(' ')
+        if len(args) != 1:
+            return 'Malformed request: !aws ecsclusterinfo <cluster name> {}'.format(args)
+        cluster_info = get_ecs_details(*args)
+        return_msg = '**{}**\n'.format(args[0])
+        for entry in cluster_info.get('clusters'):
+            if entry['clusterName'] != args[0]:
+                continue
+            return_msg += '>Status: {}\n'.format(entry['status'])
+            return_msg += '># Registered Container Instances: {}\n'.format(entry['registeredContainerInstancesCount'])
+            return_msg += '># running Tasks: {}\n'.format(entry['runningTasksCount'])
+            return_msg += '># pending Tasks: {}\n'.format(entry['pendingTasksCount'])
+            return_msg += '># active Servies: {}\n'.format(entry['activeServicesCount'])
+            
+        return return_msg
+
+    @botcmd
+    def aws_ecsclusterstatus(self, msg, args):
+        """
+        :param msg: msg sent
+        :param args: arguments passed
+        Return properties for a given ECS clusters
+        """
+        args = args.split(' ')
+        if len(args) != 1:
+            return 'Malformed request: !aws ecsclusterinfo <cluster name> {}'.format(args)
+        container_info = get_ecs_containers(*args)
+        return_msg = '**Cluster Container info for: {}**\n'.format(args[0])
+        for entry in container_info.get('containerInstances'):
+            return_msg += '>Container: {}\n'.format(entry['containerInstanceArn'])
+            return_msg += '>ec2InstanceId: {}\n'.format(entry['ec2InstanceId'])
+            return_msg += '>Container status: {}\n'.format(entry['status'])
+            return_msg += '>Docker version: {}\n'.format(entry['versionInfo']['dockerVersion'])
+            return_msg += '>Agent version: {}\n'.format(entry['versionInfo']['agentVersion'])
+            return_msg += '>Agent connected: {}\n'.format(entry['agentConnected'])
+            return_msg += '>+++++++++++++++++++++++++++++++++++++++++++++\n'
         return return_msg
 
 def get_ec2_running():
@@ -117,6 +174,22 @@ def get_ec2_value(ec2_tag, ec2_value):
 
     return values
 
+def get_ecs_info():
+    client = get_boto3_session().client('ecs')
+    result = client.list_clusters()
+    return result
+
+def get_ecs_details(name):
+    client = get_boto3_session().client('ecs')
+    result = client.describe_clusters(clusters=[name])
+    return result
+
+def get_ecs_containers(name):
+    client = get_boto3_session().client('ecs')
+    result = client.list_container_instances(cluster=name)
+    containers = result.get('containerInstanceArns',[])
+    container_info = client.describe_container_instances(cluster=name, containerInstances=containers)
+    return container_info
 
 if __name__ == '__main__':
     response = get_ec2_value('NAT', 'ip')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ nose==1.3.7
 boto3==1.1.4
 moto==0.4.14
 coveralls==1.0
+mock

--- a/tests/unittests/test_adsaws.py
+++ b/tests/unittests/test_adsaws.py
@@ -1,9 +1,11 @@
 # encoding: utf-8
 import boto3
 import unittest
-
+from mock import patch
 from moto import mock_ec2
-from adsaws import get_ec2_running, get_ec2_value
+from adsaws import get_ec2_running, get_ec2_value, get_ecs_info, get_ecs_details, get_ecs_containers
+from adsaws import AdsAws
+from boto3.session import Session
 
 class TestAdsAws(unittest.TestCase):
     """
@@ -54,3 +56,97 @@ class TestAdsAws(unittest.TestCase):
         self.assertIsInstance(ip_ec2, list)
         for d in ip_ec2:
             self.assertTrue('PrivateIpAddress' in d or 'PublicIpAddress' in d)
+
+    @patch('adsaws.get_boto3_session')
+    def test_get_ecs_info(self, mock_session):
+        mock_data = {'clusterArns': ['cluster/production','cluster/staging'],'ResponseMetadata': {}}
+        mock_session.return_value.client.return_value.list_clusters.return_value = mock_data
+        info = get_ecs_info()
+        self.assertTrue('clusterArns' in info)
+
+    @patch('adsaws.get_boto3_session')
+    def test_aws_ecsclusters(self, mock_session):
+        mock_data = {'clusterArns': ['cluster/production','cluster/staging'],'ResponseMetadata': {}}
+        mock_session.return_value.client.return_value.list_clusters.return_value = mock_data
+        foo = AdsAws()
+        return_msg = foo.aws_ecsclusters()
+        expected   = '**ADS AWS ECS Clusters**\n> production: cluster/production\n> staging: cluster/staging\n'
+        self.assertEqual(return_msg, expected)
+
+    @patch('adsaws.get_boto3_session')
+    def test_get_ecs_details(self, mock_session):
+        mock_data = {u'clusters': [{u'status': u'ACTIVE',
+                                    u'clusterName': u'staging',
+                                    u'registeredContainerInstancesCount': 3,
+                                    u'pendingTasksCount': 0,
+                                    u'runningTasksCount': 11,
+                                    u'activeServicesCount': 11}], 
+                                    'ResponseMetadata': {}}
+        mock_session.return_value.client.return_value.describe_clusters.return_value = mock_data
+        info = get_ecs_details('staging')
+        self.assertTrue('clusters' in info)
+
+    @patch('adsaws.get_boto3_session')
+    def test_aws_ecsclusters(self, mock_session):
+        mock_data = {u'clusters': [{u'status': u'ACTIVE',
+                                    u'clusterName': u'staging',
+                                    u'registeredContainerInstancesCount': 3,
+                                    u'pendingTasksCount': 0,
+                                    u'runningTasksCount': 11,
+                                    u'activeServicesCount': 11}], 
+                                    'ResponseMetadata': {}}
+        mock_session.return_value.client.return_value.describe_clusters.return_value = mock_data
+        foo = AdsAws()
+        return_msg = foo.aws_ecsclusterinfo('ecsclusterinfo','staging')
+        expected   = '**staging**\n>Status: ACTIVE\n># Registered Container Instances: 3\n># running Tasks: 11\n># pending Tasks: 0\n># active Servies: 11\n'
+        self.assertEqual(return_msg, expected)
+
+    @patch('adsaws.get_boto3_session')
+    def test_get_ecs_containers(self, mock_session):
+        mock_data = {u'failures': [], u'containerInstances': [{u'status': u'ACTIVE', 
+                                                               u'registeredResources': [{u'integerValue': 1024, u'longValue': 0, u'type': u'INTEGER', u'name': u'CPU', u'doubleValue': 0.0}, 
+                                                                                        {u'integerValue': 2004, u'longValue': 0, u'type': u'INTEGER', u'name': u'MEMORY', u'doubleValue': 0.0}, 
+                                                                                        {u'name': u'PORTS', u'longValue': 0, u'doubleValue': 0.0, u'stringSetValue': [u'22', u'2376', u'2375', u'51678'], 
+                                                                                        u'type': u'STRINGSET', u'integerValue': 0}, {u'name': u'PORTS_UDP', u'longValue': 0, u'doubleValue': 0.0, u'stringSetValue': [], 
+                                                                                        u'type': u'STRINGSET', u'integerValue': 0}],
+                                                               u'ec2InstanceId': u'i-3889f693', 
+                                                               u'agentConnected': True, 
+                                                               u'containerInstanceArn': u'ARN', 
+                                                               u'pendingTasksCount': 0, 
+                                                               u'remainingResources': [{u'integerValue': 1024, u'longValue': 0, u'type': u'INTEGER', u'name': u'CPU', u'doubleValue': 0.0},
+                                                                                       {u'integerValue': 504, u'longValue': 0, u'type': u'INTEGER', u'name': u'MEMORY', u'doubleValue': 0.0},
+                                                                                       {u'name': u'PORTS', u'longValue': 0, u'doubleValue': 0.0, u'stringSetValue': [u'22', u'2376', u'2375', u'51678'],
+                                                                                       u'type': u'STRINGSET', u'integerValue': 0}, {u'name': u'PORTS_UDP', u'longValue': 0, u'doubleValue': 0.0, u'stringSetValue': [],
+                                                                                       u'type': u'STRINGSET', u'integerValue': 0}],
+                                                               u'runningTasksCount': 5, 
+                                                               u'versionInfo': {u'agentVersion': u'1.3.0', u'agentHash': u'097e4af', u'dockerVersion': u'DockerVersion: 1.6.2'}}],
+                                                                'ResponseMetadata': {}}
+        mock_session.return_value.client.return_value.describe_container_instances.return_value = mock_data
+        info = get_ecs_containers('staging')
+        self.assertTrue('containerInstances' in info)
+
+    @patch('adsaws.get_boto3_session')
+    def test_aws_ecsclusterstatus(self, mock_session):
+        mock_data = {u'failures': [], u'containerInstances': [{u'status': u'ACTIVE', 
+                                                               u'registeredResources': [{u'integerValue': 1024, u'longValue': 0, u'type': u'INTEGER', u'name': u'CPU', u'doubleValue': 0.0}, 
+                                                                                        {u'integerValue': 2004, u'longValue': 0, u'type': u'INTEGER', u'name': u'MEMORY', u'doubleValue': 0.0}, 
+                                                                                        {u'name': u'PORTS', u'longValue': 0, u'doubleValue': 0.0, u'stringSetValue': [u'22', u'2376', u'2375', u'51678'], 
+                                                                                        u'type': u'STRINGSET', u'integerValue': 0}, {u'name': u'PORTS_UDP', u'longValue': 0, u'doubleValue': 0.0, u'stringSetValue': [], 
+                                                                                        u'type': u'STRINGSET', u'integerValue': 0}],
+                                                               u'ec2InstanceId': u'i-3889f693', 
+                                                               u'agentConnected': True, 
+                                                               u'containerInstanceArn': u'ARN', 
+                                                               u'pendingTasksCount': 0, 
+                                                               u'remainingResources': [{u'integerValue': 1024, u'longValue': 0, u'type': u'INTEGER', u'name': u'CPU', u'doubleValue': 0.0},
+                                                                                       {u'integerValue': 504, u'longValue': 0, u'type': u'INTEGER', u'name': u'MEMORY', u'doubleValue': 0.0},
+                                                                                       {u'name': u'PORTS', u'longValue': 0, u'doubleValue': 0.0, u'stringSetValue': [u'22', u'2376', u'2375', u'51678'],
+                                                                                       u'type': u'STRINGSET', u'integerValue': 0}, {u'name': u'PORTS_UDP', u'longValue': 0, u'doubleValue': 0.0, u'stringSetValue': [],
+                                                                                       u'type': u'STRINGSET', u'integerValue': 0}],
+                                                               u'runningTasksCount': 5, 
+                                                               u'versionInfo': {u'agentVersion': u'1.3.0', u'agentHash': u'097e4af', u'dockerVersion': u'DockerVersion: 1.6.2'}}],
+                                                                'ResponseMetadata': {}}
+        mock_session.return_value.client.return_value.describe_container_instances.return_value = mock_data
+        foo = AdsAws()
+        return_msg = foo.aws_ecsclusterstatus('ecsclusterstatus', 'staging')
+        expected = '**Cluster Container info for: staging**\n>Container: ARN\n>ec2InstanceId: i-3889f693\n>Container status: ACTIVE\n>Docker version: DockerVersion: 1.6.2\n>Agent version: 1.3.0\n>Agent connected: True\n>+++++++++++++++++++++++++++++++++++++++++++++\n'
+        self.assertEqual(return_msg, expected)


### PR DESCRIPTION
Created errbot commands for 

- get the names for the available clusters (with their ARNs)
- get some basic info on the cluster nodes for a given cluster
- for the nodes in a given cluster, show for each node its status, Docker version, Agent version and whether the agent is connected

Todo: implement unit tests (there doesn't seem to be a `mock_ecs` in moto?